### PR TITLE
APPCI-35 Switch to grunt-sass

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,7 +13,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-browser-sync');
-  grunt.loadNpmTasks('grunt-contrib-sass');
+  grunt.loadNpmTasks('grunt-sass');
 
   /******************************************************
    * PATTERN LAB CONFIGURATION
@@ -68,7 +68,11 @@ module.exports = function (grunt) {
     sass: {
       dist: {
         options: {
-          compass: true
+          //compass: true,
+          includePaths: [
+            "node_modules/compass-mixins/lib",
+            "node_modules/susy/sass"
+          ]
         },
         files: [{
           expand: true,

--- a/package.json
+++ b/package.json
@@ -34,7 +34,13 @@
   "engines": {
     "node": ">=5.0"
   },
+  "scripts": {
+    "test": "grunt",
+    "start": "grunt patternlab:serve"
+  },
   "devDependencies": {
-    "grunt-contrib-sass": "^1.0.0"
+    "compass-mixins": "^0.12.10",
+    "grunt-sass": "^1.2.1",
+    "susy": "^2.2.12"
   }
 }


### PR DESCRIPTION
<!-- **Please read the contribution guidelines first, and target the `dev` branch!** -->

Addresses #35

Summary of changes:

- Switches from `grunt-contrib-sass` (SASS Ruby Implementation) to `grunt-sass` (node-sass implementation)
- Brings in Susy and the Compass dependencies